### PR TITLE
Faster development builds using webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "scripts": {
     "clean": "rimraf dist",
-    "assets": "mkdirp dist && ncp assets dist/assets",
+    "assets": "npm run clean && mkdirp dist && ncp assets dist/assets",
     "build": "npm run assets && webpack -p",
-    "dev-serve": "lite-server --baseDir=dist"
+    "develop": "webpack-dev-server",
+    "develop-no-server": "npm run assets && webpack"
   },
   "private": true,
   "author": {
@@ -20,7 +21,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "lite-server": "2.3.0"
+    "null-loader": "0.1.1",
+    "webpack-dev-server": "2.4.5"
   },
   "dependencies": {
     "@types/lodash": "^4.14.63",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,12 +76,25 @@ module.exports = {
         filename: 'bundle.js'
     },
 
-    devtool: 'source-map',
+    devtool: 'cheap-eval-source-map',
 
     module: {
         loaders: [
-            {test: /\.ts$/, loader: 'ts-loader'},
-            {test: /\.css$/, loader: ExtractTextPlugin.extract({fallback: 'style-loader', use: 'css-loader'})}
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader'
+            },
+            {
+                test: /\.css$/,
+                loader: ExtractTextPlugin.extract({fallback: 'style-loader', use: 'css-loader'})},
+            {
+                test: path.resolve(__dirname, 'node_modules/webpack-dev-server/client'),
+                loader: "null-loader"
+            }
         ]
+    },
+
+    devServer:{
+        port: 9000
     }
 };


### PR DESCRIPTION
@caryoscelus  when you have a chance, please test and let me know if these changes help you.

I've changed the `npm run` names, it's now:
```
"scripts": {
    "clean": "rimraf dist",
    "assets": "npm run clean && mkdirp dist && ncp assets dist/assets",
    "build": "npm run assets && webpack -p",
    "develop": "webpack-dev-server",
    "develop-no-server": "npm run assets && webpack"
  },
```

You'll likely need to `npm install` again as some new dependencies have been added.